### PR TITLE
Collect also yaml files from argo applications

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -44,12 +44,14 @@ done
 # Run the Collection of Resources using inspect
 oc adm inspect --dest-dir must-gather --rotated-pod-logs --all-namespaces "${named_resources[@]}"
 
-# Also collect the describe command of each argo cd instance
+mkdir /must-gather/argocd
+# Also collect the describe and yaml command of each argo cd instance
 for i in argocd.argoproj.io applications.argoproj.io; do
     for j in $(oc get "${i}" -A --no-headers=true -o go-template='{{range .items}}{{ printf "%s/%s\n" .metadata.namespace .metadata.name}}{{end}}'); do
         NS=$(echo "${j}" | cut -f1 -d/)
         APP=$(echo "${j}" | cut -f2 -d/)
-        oc describe -n "${NS}" "${i}" "${APP}" > "/must-gather/${i}-${NS}-${APP}-describe.txt"
+        oc describe -n "${NS}" "${i}" "${APP}" > "/must-gather/argocd/${i}-${NS}-${APP}-describe.txt"
+        oc get -n "${NS}" "${i}" "${APP}" -o yaml > "/must-gather/argocd/${i}-${NS}-${APP}.yaml"
     done
 done
 


### PR DESCRIPTION
Tested and correctly got both describe and yaml outputs:
❯ ls quay-io-rhn-support-mbaldess-must-gather-sha256-7866e8e671d8d8a1dcfa691eac50a5b43dbf328251e247397227e31ebac92a98/argocd
applications.argoproj.io-multicloud-gitops-hub-acm-describe.txt                      applications.argoproj.io-multicloud-gitops-hub-vault-describe.txt
applications.argoproj.io-multicloud-gitops-hub-acm.yaml                              applications.argoproj.io-multicloud-gitops-hub-vault.yaml
applications.argoproj.io-multicloud-gitops-hub-config-demo-describe.txt              applications.argoproj.io-openshift-gitops-multicloud-gitops-hub-describe.txt
applications.argoproj.io-multicloud-gitops-hub-config-demo.yaml                      applications.argoproj.io-openshift-gitops-multicloud-gitops-hub.yaml
applications.argoproj.io-multicloud-gitops-hub-golang-external-secrets-describe.txt  argocd.argoproj.io-multicloud-gitops-hub-hub-gitops-describe.txt
applications.argoproj.io-multicloud-gitops-hub-golang-external-secrets.yaml          argocd.argoproj.io-multicloud-gitops-hub-hub-gitops.yaml
applications.argoproj.io-multicloud-gitops-hub-hello-world-describe.txt              argocd.argoproj.io-openshift-gitops-openshift-gitops-describe.txt
applications.argoproj.io-multicloud-gitops-hub-hello-world.yaml                      argocd.argoproj.io-openshift-gitops-openshift-gitops.yaml
